### PR TITLE
refactor GET method for festivals by id

### DIFF
--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -207,19 +207,19 @@ describe('API Routes', () => {
   });
 
   describe('/api/v1/festivals/:festivalID', () => {
-      it('GET should return a festival by id', done => {
-        chai.request(server)
-          .get('/api/v1/festivals/1')
-          .end((err, response) => {
-            response.should.have.status(200);
-            response.body.should.be.a('object');
-            response.body.should.have.property('festival_name');
-            response.body.should.have.property('start_end_dates');
-            response.body.should.have.property('city');
-            response.body.should.have.property('state_id');
-            done();
-          })
-      });
+    it('GET should return a festival by id', done => {
+      chai.request(server)
+        .get('/api/v1/festivals/1')
+        .end((err, response) => {
+          response.should.have.status(200);
+          response.body.should.be.a('array');
+          response.body[0].should.have.property('festival_name');
+          response.body[0].should.have.property('start_end_dates');
+          response.body[0].should.have.property('city');
+          response.body[0].should.have.property('state_id');
+          done();
+        })
+    });
 
     //   it('should PATCH to festivals', done => {
 


### PR DESCRIPTION
Handled together, my local machine doesn't run errors with the beforeEach hook. We will alternate driver navigator pair programming to write tests and pass them as a get around. 